### PR TITLE
Update collector port to match recent releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ go get -u github.com/rakyll/go-test-trace
 
 You can use go-test-trace as a drop-in replacement for go test.
 The following example will generate a distributed trace
-and export it to a collector available at "127.0.0.1:55680".
+and export it to a collector available at "127.0.0.1:4317".
 
 ```
 $ go-test-trace ./example
@@ -83,7 +83,7 @@ Then, you can run the collector locally by the following command
 and export the traces to Honeycomb:
 
 ```
-$ docker run --rm -p 4317:4317 -p 55680:55680 -p 8888:8888 \
+$ docker run --rm -p 4317:4317 -p 4318:4318 -p 8888:8888 \
     -v "${PWD}/example/collector.yaml":/collector.yaml \
     --name awscollector public.ecr.aws/aws-observability/aws-otel-collector:latest \
     --config collector.yaml;

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ var collectedSpans = make(map[string]*spanData, 1000)
 
 func main() {
 	fset := flag.NewFlagSet("", flag.ContinueOnError)
-	fset.StringVar(&endpoint, "endpoint", "127.0.0.1:55680", "")
+	fset.StringVar(&endpoint, "endpoint", "127.0.0.1:4317", "")
 	fset.StringVar(&name, "name", "go-test-trace", "")
 	fset.BoolVar(&stdin, "stdin", false, "")
 	fset.BoolVar(&help, "help", false, "")
@@ -186,7 +186,7 @@ go-test-trace [flags...] [go test flags...]
 
 Flags:
 -name        Name of the trace span created for the test, optional.
--endpoint    OpenTelemetry gRPC collector endpoint, 127.0.0.1:55680 by default.
+-endpoint    OpenTelemetry gRPC collector endpoint, 127.0.0.1:4317 by default.
 -traceparent Trace to participate into if any, in W3C Trace Context format.
 -stdin       Parse go test verbose output from stdin.
 -help        Print this text.


### PR DESCRIPTION
The `55860` legacy port was removed in `v0.35.0` of the upstream
collector and `v0.13.0` of the ADOT collector.
https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.35.0
https://github.com/aws-observability/aws-otel-collector/releases/tag/v0.13.0
