### PR TITLE
Rely on supported env variables if no endpoint is specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,11 +63,16 @@ func main() {
 
 func trace(args []string) error {
 	ctx := context.Background()
-	traceExporter, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithInsecure(),
-		otlptracegrpc.WithEndpoint(endpoint),
-		otlptracegrpc.WithTimeout(100*time.Millisecond),
-	)
+	otlpOpts := []otlptracegrpc.Option{
+		otlptracegrpc.WithTimeout(100 * time.Millisecond),
+	}
+	if endpoint != "" {
+		otlpOpts = append(otlpOpts,
+			otlptracegrpc.WithInsecure(),
+			otlptracegrpc.WithEndpoint(endpoint),
+		)
+	}
+	traceExporter, err := otlptracegrpc.New(ctx, otlpOpts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This allows using the environment variables provided by OpenTelemetry to configure the OTLP exporter instead of the collector.
Example:

```
OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io:443 OTEL_EXPORTER_OTLP_HEADERS=x-honeycomb-team=foobar go-test-trace ./...
```